### PR TITLE
Adding 2 yearly inputs, year validation, title rendering

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -16,12 +16,28 @@ def server(input: Inputs, output: Outputs, session: Session):
     # Reactive Filters
     # =============================
     @reactive.Calc
-    def selected_year():
-        """Safe year value; input_numeric may return None when empty."""
-        y = input.year()
-        if y is None:
-            return 1950
-        return max(min_year, min(max_year, int(y)))
+    def selected_range():
+        b = input.baseline_year()
+        t = input.target_year()
+
+        if b is None or t is None:
+            return None, None, "Enter both years."
+
+        try:
+            b, t = int(b), int(t)
+        except (TypeError, ValueError):
+            return None, None, "Years must be numeric."
+
+        if not (min_year <= b <= max_year):
+            return None, None, f"Reference year must be between {min_year} and {max_year}."
+
+        if not (min_year <= t <= max_year):
+            return None, None, f"Target year must be between {min_year} and {max_year}."
+
+        if t <= b:
+            return None, None, "Target year must be greater than reference year."
+
+        return b, t, None
 
     @reactive.Calc
     def filtered_yearly_data():
@@ -31,7 +47,22 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.Calc
     def filtered_global_data():
         """Global data for the selected year"""
-        return df_yearly[df_yearly["year"] == selected_year()]
+        b, t, err = selected_range()
+        if err:
+            return pd.DataFrame()
+
+        data = filtered_yearly_data()
+        return data[(data["year"] >= b) & (data["year"] <= t)]
+
+    # =============================
+    # Year Validation UI
+    # =============================
+    @render.ui
+    def year_validation_ui():
+        _, _, err = selected_range()
+        if err:
+            return ui.div(err, class_="text-danger")
+        return ui.div("Year range is valid.", class_="text-success")
 
     # =============================
     # Data Count UI
@@ -39,9 +70,14 @@ def server(input: Inputs, output: Outputs, session: Session):
     @render.ui
     def data_count_ui():
         """Render the data count UI element"""
-        data = filtered_yearly_data()
-        year = selected_year()
-        curr_year_data = data[data["year"] == year]
+        data = filtered_range_data()
+
+        b, t, err = selected_range()
+        if err:
+            return
+
+        baseline_data = data[data["year"] == b]
+        target_data = data[data["year"] == t]
 
         if not curr_year_data.empty:
             temp = curr_year_data.iloc[0]["avg_temp"]
@@ -65,7 +101,12 @@ def server(input: Inputs, output: Outputs, session: Session):
     @render.ui
     def event_ui():
         """Render historical context based on year range"""
-        year = selected_year()
+
+        # Guard against invalid year inputs
+        b, t, err = selected_range()
+        if err:
+            return
+
         # Event Place holder
         events = [
             (1860, 1900, "Post-Industrial Revolution"),
@@ -89,6 +130,12 @@ def server(input: Inputs, output: Outputs, session: Session):
     @render.ui
     def seasonal_temp_ui():
         """Render the seasonal temperature UI element"""
+
+        # Guard against invalid year inputs
+        b, t, err = selected_range()
+        if err:
+            return
+
         mask = (df_seasonal["Country"] == input.country()) & (
             df_seasonal["year"] == selected_year())
         curr_data = df_seasonal[mask]
@@ -118,8 +165,12 @@ def server(input: Inputs, output: Outputs, session: Session):
     # =============================
     @render.ui
     def title_placeholder():
-        """Placeholder for future year-difference or dashboard title logic."""
-        return "Comparing Placeholder"
+        # Guard against invalid year inputs
+        b, t, err = selected_range()
+        if err:
+            return ...
+
+        return f"{b} to {t}"
 
     # =============================
     # Data Table (Line Plot Data)

--- a/src/ui.py
+++ b/src/ui.py
@@ -13,10 +13,20 @@ country_selector = ui.input_select(
     selected="Canada"
 )
 
-year_input = ui.input_numeric(
-    "year",
-    "Select Year:",
+baseline_year_input = ui.input_numeric(
+    "baseline_year",
+    "Select Reference Year:",
     value=1950,
+    min=min_year,
+    max=max_year,
+    step=1,
+    width="100%"
+)
+
+target_year_input = ui.input_numeric(
+    "target_year",
+    "Select Target Year:",
+    value=2000,
     min=min_year,
     max=max_year,
     step=1,
@@ -42,10 +52,12 @@ map_projection_selector = ui.input_select(
 # ==========================================
 app_sidebar = ui.sidebar(
     country_selector,
-    year_input,
+    baseline_year_input,
+    target_year_input,
+    ui.output_ui("year_validation_ui"),
     title="Filters",
     open="desktop",
-    id="app_sidebar"
+    id="app_sidebar",
 )
 
 # ==========================================


### PR DESCRIPTION
## Summary
This PR updates the app from a single-year input to a two-year comparison range in the sidebar.

## Changes
- Replaced `year` input with:
  - `baseline_year` (`input_numeric`)
  - `target_year` (`input_numeric`)
- Added reactive range validation in `app.py`:
  - requires both years
  - enforces numeric values
  - enforces `[min_year, max_year]`
  - enforces `target_year > baseline_year`
- Added inline validation feedback UI:
  - `ui.output_ui("year_validation_ui")` in sidebar
- Wired title value box placeholder to selected range:
  - displays `"baseline_year to target_year"`

## Notes
- This PR mainly establishes input/validation scaffolding.
- Some downstream outputs still need migration from old single-year references (`selected_year`, `input.year`) to the new range-based flow.

## Follow-up Work
- Update all year-dependent outputs (cards/plots/table/map) to use `selected_range()`.
- Replace placeholder invalid-state returns with renderer-appropriate empty outputs where needed.