### PR TITLE
Docs: Synchronize M2 Spec with Implementation

### DIFF
--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -11,6 +11,8 @@ Review your M1 job stories in light of your deployment setup and any new insight
 | 5   | When I select a country on the heatmap, I want it to zoom in on the selected country so I can focus on its local temperature patterns. | ⏳ Pending M3 |   Zoom functionality not yet implemented; planned for next milestone.                            |
 | 6   | When I select two years for a country, I want to compare seasonal temperature changes side by side so I can analyze warming or cooling trends. | ✅ Implemented |                              |
 | 7   | When I open the dashboard, I want to see a compact, informative title showing country, years, and “Temp Comparison” so I can immediately understand the view. | ✅ Implemented |                              |
+| 8   | When I select two years for a country, I want to view a monthly dual-line overlay of average temperatures so I can compare seasonal warming or cooling patterns month by month. | ✅ Implemented | Altair line chart; smooth curves, tooltip, hover rule, legend. |
+| 9   | When I view the monthly comparison, I want to see a table with baseline/target averages and change values, with color coding for the magnitude of change, so I can quickly identify which months warmed or cooled and export the data. | ✅ Implemented | Red (warmer) / blue (cooler) on Change column; CSV export. |
 
 ### 2.2 Component Inventory
 
@@ -22,42 +24,82 @@ Plan every input, reactive calc, and output your app will have. Use this as a ch
 | `baseline_year`       | Input         | `ui.input_numeric()`    | —                                   | #1, #6             |
 | `target_year`         | Input         | `ui.input_numeric()`    | —                                   | #1, #6             |
 | `selected_range`      | Reactive calc | `@reactive.Calc`        | `baseline_year`, `target_year`      | #1, #6             |
-| `filtered_yearly`     | Reactive calc | `@reactive.Calc`        | `input_country`                     | #1, #3             |
-| `filtered_global`     | Reactive calc | `@reactive.Calc`        | `filtered_yearly`, `selected_range` | #3, #4, #5         |
-| `monthly_comparison`  | Reactive calc | `@reactive.Calc`        | `filtered_yearly`, `selected_range` | #1                 |
-| `seasonal_comparison` | Reactive calc | `@reactive.Calc`        | `filtered_yearly`, `selected_range` | #1, #6             |
-| `temp_plot`           | Output        | `@render_altair`        | `monthly_comparison`                | #1                 |
-| `seasonal_temp_ui`    | Output        | `@render.data_frame`    | `seasonal_comparison`               | #1, #6             |
+| `filtered_yearly`     | Reactive calc | `@reactive.Calc`        | `input_country`                     | #1                 |
+| `filtered_global`     | Reactive calc | `@reactive.Calc`        | `filtered_yearly`, `selected_range` | #1, #6             |
+| `monthly_comparison`  | Reactive calc | `@reactive.Calc`        | `input_country`, `selected_range`, `df_monthly` | #1, #8, #9         |
+| `year_validation_ui`  | Output        | `@render.ui`            | `selected_range`                    | #1, #6             |
+| `temp_plot`           | Output        | `@render_altair`        | `monthly_comparison`                | #1, #8             |
+| `seasonal_temp_ui`    | Output        | `@render.data_frame`    | `input_country`, `selected_range`, `df_seasonal` | #1, #6             |
 | `data_count_ui`       | Output        | `@render.ui`            | `filtered_global`                   | #1, #6             |
 | `event_ui`            | Output        | `@render.ui`            | `selected_range`                    | #2                 |
 | `title_placeholder`   | Output        | `@render.ui`            | `input_country`, `selected_range`   | #7                 |
-| `map_plot`            | Output        | `@render_widget`        | `filtered_global`                   | #3, #4, #5         |
-| `data_table`          | Output        | `@render.data_frame`    | `monthly_comparison`                | #1                 |
-| `download_table_csv`  | Output        | `@render.download`      | `monthly_comparison`                | #1                 |
+| `map_plot`            | Output        | `@render_widget`        | `df_yearly` (target year), `input_country`, `selected_range` | #3, #4, #5         |
+| `data_table`          | Output        | `@render.data_frame`    | `monthly_comparison`                | #1, #9             |
+| `download_table_csv`  | Output        | `@render.download`      | `monthly_comparison`                | #1, #9             |
 
 
 ### 2.3 Reactivity Diagram
 
 ```mermaid
 flowchart TD
-  C[Country] --> FB{{Filtered DF of Base Year}}
-  C[Country] --> FS{{Filtered DF of Select Year}}
-  B[Base Year] --> FB
-  S[Select Year] --> FS
-  C --> TITLE([title])
-  B --> TITLE([title])
-  S --> TITLE([title])
-  B --> HIST([Historical Events])
-  S --> HIST([Historical Events])
-  FB --> YB([Base Year Average Temp])
-  FS --> YS([Select Year Average Temp])
-  FB --> ST([Seasonal Average Temp])
-  FS --> ST([Seasonal Average Temp])
-  FB --> MLP([Monthly Temp Line Chart])
-  FS --> MLP([Monthly Temp Line Chart])
-  FB --> WM([World Map Temp Difference])
-  FS --> WM([World Map Temp Difference])
-  C --> WM([World Map Temp Difference])
+  subgraph Inputs
+    C[Country]
+    B[Base Year]
+    S[Target Year]
+  end
+
+  subgraph Reactive Calcs
+    SR[selected_range]
+    FY[filtered_yearly]
+    FG[filtered_global]
+    MC[monthly_comparison]
+  end
+
+  subgraph Data Sources
+    DY[(df_yearly)]
+    DM[(df_monthly)]
+    DS[(df_seasonal)]
+  end
+
+  subgraph Outputs
+    TITLE([title])
+    VALID([year_validation_ui])
+    HIST([Historical Events])
+    DC([data_count_ui])
+    ST([Seasonal Temp Table])
+    MLP([Monthly Line Chart])
+    DT([Data Table])
+    CSV([CSV Download])
+    WM([World Map])
+  end
+
+  B --> SR
+  S --> SR
+  C --> FY
+  DY --> FY
+  FY --> FG
+  SR --> FG
+  C --> MC
+  SR --> MC
+  DM --> MC
+
+  SR --> TITLE
+  C --> TITLE
+  SR --> VALID
+  SR --> HIST
+  FG --> DC
+
+  C --> ST
+  SR --> ST
+  DS --> ST
+
+  MC --> MLP
+  MC --> DT
+  MC --> CSV
+
+  S --> WM
+  C --> WM
+  DY --> WM
 ```
 
 ### 2.4 Calculation Details
@@ -70,8 +112,7 @@ For each `@reactive.calc` in your diagram, briefly describe:
 
 | Reactive Calc         | Depends on                          | Transformation / Logic                                                                                       | Consumed by / Outputs                                            |
 | --------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------- |
-| `selected_range`      | `baseline_year`, `target_year`      | Calculates the selected year range and validates it. Returns `(baseline_year, target_year, error_flag)`      | `monthly_comparison`, `seasonal_comparison`, `title_placeholder` |
-| `filtered_yearly`     | `input_country`                     | Filters the main temperature dataset for the selected country.                                               | `monthly_comparison`, `seasonal_comparison`, `filtered_global`   |
-| `filtered_global`     | `filtered_yearly`, `selected_range` | Combines filtered yearly data with selected range to produce a dataset suitable for world heatmap comparison | `map_plot`, `data_count_ui`                                      |
-| `monthly_comparison`  | `filtered_yearly`, `selected_range` | Computes monthly temperature statistics for both baseline and target years, used for plotting trends         | `temp_plot`, `data_table`, `download_table_csv`                  |
-| `seasonal_comparison` | `filtered_yearly`, `selected_range` | Calculates seasonal averages for baseline and target years and computes changes                              | `seasonal_temp_ui`, `data_count_ui`                              |
+| `selected_range`      | `baseline_year`, `target_year`      | Validates year inputs and returns `(baseline_year, target_year, error_flag)`. Rejects if target ≤ baseline.   | `monthly_comparison`, `filtered_global`, `year_validation_ui`, `event_ui`, `title_placeholder` |
+| `filtered_yearly`     | `input_country`                     | Filters `df_yearly` by selected country.                                                                     | `filtered_global` only                                           |
+| `filtered_global`     | `filtered_yearly`, `selected_range` | Filters `filtered_yearly` by year in [baseline, target]. Yearly avg data for both years.                     | `data_count_ui` only (map uses `df_yearly` directly for target year) |
+| `monthly_comparison`  | `input_country`, `selected_range`, `df_monthly` | Filters `df_monthly` by country and both years; merges baseline/target; adds Month, Change (red/blue semantics). | `temp_plot`, `data_table`, `download_table_csv`                  |


### PR DESCRIPTION
## Summary

This PR updates `reports/m2_spec.md` (sections 2.1, 2.2, 2.3, 2.4) to match the current TempTales dashboard implementation in `src/app.py`. The spec previously described a planned or outdated design; it now reflects the actual data flow and reactive dependency structure. The reactivity diagram (2.3) has been rewritten to align with the correct calc chain and data sources.

---

## Misconceptions Before Modification

### 1. `monthly_comparison` depended on `filtered_yearly`

**Spec (before):**  
`monthly_comparison` depended on `filtered_yearly` and `selected_range`.

**Reality:**  
`monthly_comparison_data()` uses `df_monthly` directly, filtered by `input.country()` and years from `selected_range()`. It does **not** consume `filtered_yearly_data()`. The monthly chart and table are built from monthly aggregates, not yearly.

### 2. `seasonal_comparison` calc existed

**Spec (before):**  
A reactive calc `seasonal_comparison` existed, depending on `filtered_yearly` and `selected_range`, and feeding `seasonal_temp_ui` and `data_count_ui`.

**Reality:**  
There is no `seasonal_comparison` calc. `seasonal_temp_ui` reads `df_seasonal` directly, filtered by `input.country()` and both years from `selected_range()`. `data_count_ui` uses `filtered_global_data()`, not any seasonal calc.

### 3. `filtered_global` fed the map

**Spec (before):**  
`map_plot` was listed as consuming `filtered_global`.

**Reality:**  
`update_map_data()` uses `df_yearly[df_yearly["year"] == t]` (target year only) and reindexes for all countries. It never calls `filtered_global_data()`. The map shows global yearly temperatures for the target year, not country-filtered data.

### 4. `filtered_yearly` fed multiple outputs

**Spec (before):**  
`filtered_yearly` was consumed by `monthly_comparison`, `seasonal_comparison`, and `filtered_global`.

**Reality:**  
`filtered_yearly_data()` is consumed **only** by `filtered_global_data()`. `filtered_global_data()` is consumed **only** by `data_count_ui` (yearly average temp display for both baseline and target years).

### 5. Missing `year_validation_ui`

**Spec (before):**  
`year_validation_ui` was not in the component inventory.

**Reality:**  
`year_validation_ui()` exists in `app.py` and displays validation messages for the year inputs.

### 6. Reactivity diagram (2.3) showed incorrect data flow

**Spec (before):**  
The diagram showed FB (Filtered DF of Base Year) and FS (Filtered DF of Select Year) feeding all outputs: YB, YS, ST, MLP, WM. Everything was derived from country-filtered yearly data split by year.

**Reality:**  
The implementation uses three distinct data sources (`df_yearly`, `df_monthly`, `df_seasonal`). Only `data_count_ui` uses the filtered_yearly → filtered_global chain. The monthly chart/table use `df_monthly` via `monthly_comparison`. The seasonal table reads `df_seasonal` directly. The map uses `df_yearly` for the target year across all countries, not filtered by country.

---

## Current Logic After Modification

### Reactive calc chain

| Calc | Depends on | Logic | Consumed by |
|------|------------|-------|-------------|
| `selected_range` | `baseline_year`, `target_year` | Validates inputs; returns `(b, t, err)`. Rejects if target ≤ baseline. | `monthly_comparison`, `filtered_global`, `year_validation_ui`, `event_ui`, `title_placeholder` |
| `filtered_yearly` | `input_country` | Filters `df_yearly` by country. | `filtered_global` only |
| `filtered_global` | `filtered_yearly`, `selected_range` | Filters by year in [baseline, target]. Yearly data for both years. | `data_count_ui` only |
| `monthly_comparison` | `input_country`, `selected_range`, `df_monthly` | Filters `df_monthly` by country and both years; merges baseline/target; adds Month, Change. | `temp_plot`, `data_table`, `download_table_csv` |

### Outputs and data sources

- **`seasonal_temp_ui`** — reads `df_seasonal` directly (no `seasonal_comparison` calc).
- **`map_plot` / `update_map_data`** — reads `df_yearly` directly for target year; no `filtered_global`.
- **`data_count_ui`** — uses `filtered_global_data()` to show yearly avg temp and observation count for both years.
- **`temp_plot`**, **`data_table`**, **`download_table_csv`** — all use `monthly_comparison_data()`.

---

## New Job Stories Added in 2.1

| # | Job Story | Status |
|---|-----------|--------|
| **8** | When I select two years for a country, I want to view a monthly dual-line overlay of average temperatures so I can compare seasonal warming or cooling patterns month by month. | ✅ Implemented |
| **9** | When I view the monthly comparison, I want to see a table with baseline/target averages and change values, with color coding for the magnitude of change, so I can quickly identify which months warmed or cooled and export the data. | ✅ Implemented |

**Rationale:**  
- **#8** — Describes the Altair monthly dual-line chart (smooth curves, tooltip, legend).  
- **#9** — Describes the monthly data table (red/blue change column, CSV export).

---

## Files Changed

- `reports/m2_spec.md`:
  - **2.1** — New job stories (#8 line plot, #9 data table)
  - **2.2** — Component inventory aligned with implementation (monthly_comparison deps, seasonal_temp_ui direct df_seasonal, map df_yearly, year_validation_ui added)
  - **2.3** — Reactivity diagram rewritten to show correct flow: inputs → reactive calcs (selected_range, filtered_yearly, filtered_global, monthly_comparison) → outputs; three data sources (df_yearly, df_monthly, df_seasonal) with accurate consumers
  - **2.4** — Calculation details updated (seasonal_comparison removed, filtered_yearly/filtered_global/monthly_comparison corrected)
