### PR TITLE
Implemented AI tab outputs

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -12,7 +12,7 @@ from src.chat import qc
 # =====================================
 from src.utils import df_yearly, df_seasonal, df_monthly, min_year, max_year
 from src.ui import app_ui
-from src.plot import build_temp_chart
+from src.plot import build_temp_chart, build_yearly_plot
 from src.data_count import data_count_prep
 from src.map import build_base_map, apply_country_highlight
 
@@ -426,9 +426,24 @@ def server(input: Inputs, output: Outputs, session: Session):
     # AI Plots
     # =====================================
 
+    @reactive.Calc
+    def ai_monthly_prep():
+        df = ai_filtered_raw_data()
+        if df.empty:
+            return pd.DataFrame()
+        df_yearly = df.groupby(["Country", "year"], as_index=False)["AvgTemp"].mean()
+        # center by country (subtracting long-term mean)
+        df_yearly["AvgTemp_centered"] = df_yearly.groupby("Country")["AvgTemp"].transform(lambda x: x - x.mean())
+        
+        return df_yearly
+
     @render_widget
     def ai_centred_ts_plot():
-        pass
+        df = ai_monthly_prep()
+        if df.empty: 
+            return None
+        plot = build_yearly_plot(df)
+        return plot
 
     @render_widget
     def ai_monthly_change_plot():

--- a/src/app.py
+++ b/src/app.py
@@ -398,11 +398,22 @@ def server(input: Inputs, output: Outputs, session: Session):
     @reactive.Calc
     def ai_filtered_raw_data():
         df = qc_vals.df()
-        return df if isinstance(df, pd.DataFrame) else pd.DataFrame(df)
+        print("AI RETURN TYPE:", type(df))
+        # return df if isinstance(df, pd.DataFrame) else pd.DataFrame(df)
+        if df is None:
+            return pd.DataFrame()
+        if isinstance(df, pd.DataFrame):
+            return df
+        return pd.DataFrame(df)
 
     @render.data_frame
     def ai_data_frame():
-        return render.DataGrid(ai_filtered_raw_data(), selection_mode="none", height="100%")
+        # return render.DataGrid(ai_filtered_raw_data(), selection_mode="none", height="100%")
+        df = ai_filtered_raw_data()
+        if df.empty:
+            # placeholder message
+            return pd.DataFrame({"Message": ["Ask the AI a question to see results"]})
+        return df
 
     @render.download(filename="ai_filtered_data.csv")
     def download_ai_table_csv():

--- a/src/app.py
+++ b/src/app.py
@@ -3,6 +3,7 @@ import io
 from shiny import App, Inputs, Outputs, Session, reactive, render, ui
 from shinywidgets import render_altair, render_plotly, render_widget
 import plotly.graph_objects as go
+import altair as alt
 import pandas as pd
 
 from src.chat import qc
@@ -12,7 +13,7 @@ from src.chat import qc
 # =====================================
 from src.utils import df_yearly, df_seasonal, df_monthly, min_year, max_year
 from src.ui import app_ui
-from src.plot import build_temp_chart, build_yearly_plot
+from src.plot import build_temp_chart, build_yearly_plot, build_diff_plot
 from src.data_count import data_count_prep
 from src.map import build_base_map, apply_country_highlight
 
@@ -427,27 +428,65 @@ def server(input: Inputs, output: Outputs, session: Session):
     # =====================================
 
     @reactive.Calc
-    def ai_monthly_prep():
+    def ai_yearly_prep():
         df = ai_filtered_raw_data()
         if df.empty:
-            return pd.DataFrame()
-        df_yearly = df.groupby(["Country", "year"], as_index=False)["AvgTemp"].mean()
-        # center by country (subtracting long-term mean)
+            return pd.DataFrame(columns=["Country", "year", "AvgTemp", "AvgTemp_centered"])
+        df_yearly = df.groupby(["Country", "year"], 
+                               as_index=False)["AvgTemp"].mean()
         df_yearly["AvgTemp_centered"] = df_yearly.groupby("Country")["AvgTemp"].transform(lambda x: x - x.mean())
-        
-        return df_yearly
+        return df_yearly.head(3000)
 
     @render_widget
     def ai_centred_ts_plot():
-        df = ai_monthly_prep()
-        if df.empty: 
-            return None
+        df = ai_yearly_prep()
+        # Always return a valid plot even if empty
+        if df.empty:
+            return alt.Chart(pd.DataFrame(columns=["year", "AvgTemp_centered", "Country"])).mark_line()
         plot = build_yearly_plot(df)
         return plot
 
+    @reactive.Calc
+    def ai_monthly_diff_prep():
+        df = ai_filtered_raw_data()
+        if df.empty:
+            return None  # no user input yet
+
+        # Get years in the filtered df
+        years = sorted(df["year"].unique())
+        if len(years) == 1:
+            year1 = years[0]
+            year2 = df["year"].max()  # latest year in dataset
+        else:
+            year1, year2 = years[0], years[-1]  # min & max years
+
+        # Filter for the two years only
+        df_filtered = df[df["year"].isin([year1, year2])]
+
+        # Pivot to have one column per year for monthly comparison
+        df_pivot = df_filtered.pivot_table(
+            index=["Country", "month"],
+            columns="year",
+            values="AvgTemp"
+        ).reset_index()
+
+        # Rename columns for clarity
+        df_pivot = df_pivot.rename(columns={year1: "year1_temp", year2: "year2_temp"})
+
+        # Compute difference
+        df_pivot["AvgTemp_diff"] = df_pivot["year2_temp"] - df_pivot["year1_temp"]
+
+        # Keep only needed columns
+        return df_pivot[["Country", "month", "AvgTemp_diff"]]
+
     @render_widget
     def ai_monthly_change_plot():
-        pass
-
+        df = ai_monthly_diff_prep()
+        if df is None or df.empty:
+            return alt.Chart(pd.DataFrame(columns=["month", "AvgTemp_diff", "Country"])).mark_line()
+        
+        plot = build_diff_plot(df)
+        return plot
+    
 
 app = App(app_ui, server)

--- a/src/app.py
+++ b/src/app.py
@@ -399,7 +399,6 @@ def server(input: Inputs, output: Outputs, session: Session):
     def ai_filtered_raw_data():
         df = qc_vals.df()
         print("AI RETURN TYPE:", type(df))
-        # return df if isinstance(df, pd.DataFrame) else pd.DataFrame(df)
         if df is None:
             return pd.DataFrame()
         if isinstance(df, pd.DataFrame):
@@ -408,10 +407,8 @@ def server(input: Inputs, output: Outputs, session: Session):
 
     @render.data_frame
     def ai_data_frame():
-        # return render.DataGrid(ai_filtered_raw_data(), selection_mode="none", height="100%")
         df = ai_filtered_raw_data()
         if df.empty:
-            # placeholder message
             return pd.DataFrame({"Message": ["Ask the AI a question to see results"]})
         return df
 

--- a/src/chat.py
+++ b/src/chat.py
@@ -1,10 +1,11 @@
 import os
 import pandas as pd
+import numpy as np
 from dotenv import load_dotenv
 import chatlas as ctl
 from querychat import QueryChat
 
-from .utils import df_yearly
+from .utils import df_monthly
 
 load_dotenv()
 
@@ -12,13 +13,33 @@ chat = ctl.ChatGithub(
     api_key=os.getenv("GITHUB_API_KEY"),
     model = "gpt-4.1-mini",
     #system_prompt = "You are a helpful weather assistant."
-    system_prompt = "You are a helpful assistant."
+    # system_prompt = "You are a helpful assistant."
+    system_prompt = """
+        You are a climate data assistant for the TempTales dashboard.
+
+        You help users explore historical temperature data across countries.
+        This is the dataset provided for you: 
+        * temperature_data:
+            Monthly average temperature per country.    
+
+        When possible:
+        - Answer questions using the dataset
+        - Suggest useful data queries
+        - Help interpret climate trends
+        - Be concise and clear
+    """
 )
+
+# qc = QueryChat(
+#     df_yearly,
+#     "temperature_data",
+#     client=chat
+# )
+df_monthly["AvgTemp"] = np.round(df_monthly["AvgTemp"], 2)
 
 qc = QueryChat(
-    df_yearly,
-    "temperature_data",
+    df_monthly, 
+    "temperature_data", 
     client=chat
 )
-
 

--- a/src/chat.py
+++ b/src/chat.py
@@ -30,11 +30,6 @@ chat = ctl.ChatGithub(
     """
 )
 
-# qc = QueryChat(
-#     df_yearly,
-#     "temperature_data",
-#     client=chat
-# )
 df_monthly["AvgTemp"] = np.round(df_monthly["AvgTemp"], 2)
 
 qc = QueryChat(

--- a/src/plot.py
+++ b/src/plot.py
@@ -132,3 +132,31 @@ def build_temp_chart(
         )
     )
     return chart
+
+
+def build_yearly_plot(df_yearly: pd.DataFrame): 
+    """_summary_
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        _description_
+    """
+    plot = (
+        alt.Chart(df_yearly)
+        .mark_line(point=True)
+        .encode(
+            x=alt.X("year:O", title="Year"), 
+            y=alt.Y("AvgTemp_centered:Q", title="Centered Avg Temp (°C)"),
+            color=alt.Color("Country:N"),
+            tooltip=["Country", "year", "AvgTemp_centered"]
+        )
+        .properties(
+            height=300,
+            width="container",
+            title="Centered Yearly Avg Temperature by Country"
+        )
+        .interactive()  # allows zooming & panning
+    )
+
+    return plot

--- a/src/plot.py
+++ b/src/plot.py
@@ -156,7 +156,27 @@ def build_yearly_plot(df_yearly: pd.DataFrame):
             width="container",
             title="Centered Yearly Avg Temperature by Country"
         )
-        .interactive()  # allows zooming & panning
+        .interactive() 
     )
 
     return plot
+
+def build_diff_plot(df_monthly_diff): 
+    plot = (
+            alt.Chart(df_monthly_diff)
+            .mark_line(point=True)
+            .encode(
+                x=alt.X("month:O", title="Month"),
+                y=alt.Y("AvgTemp_diff:Q", title="Monthly Avg Temp Difference (°C)"),
+                color=alt.Color("Country:N"),
+                tooltip=["Country", "month", "AvgTemp_diff"]
+            )
+            .properties(
+                height=300,
+                width="container",
+                title="Monthly Avg Temperature Difference by Country"
+            )
+            .interactive()
+        )
+    return plot
+


### PR DESCRIPTION
**Highlight changes:** 
- Updated Chatbot `system_prompt` to more detailed objectives
- Changed Chatbot's query dataframe from `df_yearly` to `df_monthly` because monthly compare line plot is needed
- Fixed rendering error of `ai_data_frame()` from using DataGrid
- Implemented `ai_centred_ts_plot()` and `ai_monthly_change_plot()` function for the AI tab output
- 2 helper functions (`build_yearly_plot()`, `build_diff_plot()`) in `plot.py`

**Issues:** 
- Default dataset (`df_monthly`) is too big, causing the rendering plots, df, shiny, chatbot to be unstable (need to wait for grey screen or extra loading time for plots to render), especially for _Time Series (Center data) plot_ (needs agg & all years btw the given year, default is all year...)
- Temporary fix: only pass down top 3000 lines of data so that it can be rendered properly (for generating Time Series (Center data) plot)
    * Potential Issues: 
        - if the filtered data (based on user's query) was originally more than 3000 entries, the plot will be incomplete
        - using `alt.data_transformers.enable("vegafusion")` will crash because vegafusion + Shiny doesn’t play nicely (Shiny expects the full chart object with embedded data, whereas VegaFusion offloads transforms to Python and changes the chart’s internal representation.)

<img width="1253" height="618" alt="Screenshot 2026-03-07 at 1 31 22 AM" src="https://github.com/user-attachments/assets/4e290b99-0f51-493f-a6db-ff24ecb83738" />

completed #77 